### PR TITLE
Add valid_before and valid_after fields

### DIFF
--- a/component/src/action_handler/actions/spend.rs
+++ b/component/src/action_handler/actions/spend.rs
@@ -60,6 +60,7 @@ mod tests {
     use std::sync::Arc;
 
     use anyhow::Result;
+    use ibc::timestamp::Timestamp;
     use penumbra_chain::test_keys;
     use penumbra_crypto::{transaction::Fee, Note, Value, STAKING_TOKEN_ASSET_ID};
     use penumbra_tct as tct;
@@ -103,6 +104,8 @@ mod tests {
         // transaction balances.
         let plan = TransactionPlan {
             expiry_height: 0,
+            valid_after: Timestamp::none(),
+            valid_before: Timestamp::none(),
             fee: Fee::default(),
             chain_id: "".into(),
             actions: vec![
@@ -166,6 +169,8 @@ mod tests {
         // transaction balances.
         let plan = TransactionPlan {
             expiry_height: 0,
+            valid_after: Timestamp::none(),
+            valid_before: Timestamp::none(),
             fee: Fee::default(),
             chain_id: "".into(),
             actions: vec![

--- a/component/src/action_handler/transaction.rs
+++ b/component/src/action_handler/transaction.rs
@@ -10,7 +10,7 @@ use tracing::{instrument, Instrument};
 
 use crate::shielded_pool::consensus_rules;
 
-use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid};
+use self::stateful::{claimed_anchor_is_valid, fmd_parameters_valid, timestamps_are_valid};
 
 use super::ActionHandler;
 
@@ -56,6 +56,7 @@ impl ActionHandler for Transaction {
     async fn check_stateful<S: StateRead + 'static>(&self, state: Arc<S>) -> Result<()> {
         claimed_anchor_is_valid(state.clone(), self).await?;
         fmd_parameters_valid(state.clone(), self).await?;
+        timestamps_are_valid(state.clone(), self).await?;
 
         // Currently, we need to clone the component actions so that the spawned
         // futures can have 'static lifetimes. In the future, we could try to

--- a/component/src/action_handler/transaction/stateful.rs
+++ b/component/src/action_handler/transaction/stateful.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use ibc::timestamp::Timestamp;
 use penumbra_chain::StateReadExt as _;
 use penumbra_storage::StateRead;
 use penumbra_transaction::Transaction;
@@ -31,4 +32,32 @@ pub(super) async fn fmd_parameters_valid<S: StateRead>(
         current_fmd_parameters,
         height,
     )
+}
+
+pub(super) async fn timestamps_are_valid<S: StateRead>(
+    state: S,
+    transaction: &Transaction,
+) -> Result<()> {
+    let current_time: Timestamp = state.get_block_timestamp().await?.into();
+
+    let after = transaction.transaction_body().valid_after;
+
+    let before = transaction.transaction_body().valid_before;
+
+    if current_time.check_expiry(&after) == ibc::timestamp::Expiry::Expired {
+        anyhow::bail!("Too late!");
+    }
+
+    if before.check_expiry(&current_time) == ibc::timestamp::Expiry::Expired {
+        anyhow::bail!("Too early!");
+    }
+
+    if transaction.transaction_body().expiry_height != 0 {
+        let current_block = state.get_block_height().await?;
+        if current_block > transaction.transaction_body().expiry_height {
+            anyhow::bail!("Too late!");
+        }
+    }
+
+    Ok(())
 }

--- a/pcli/src/command/view/tx.rs
+++ b/pcli/src/command/view/tx.rs
@@ -340,6 +340,14 @@ impl TxCmd {
                 "Transaction Expiration Height",
                 &format!("{}", txv.expiry_height),
             ]);
+            metadata_table.add_row(vec![
+                "Transaction Valid Before",
+                &format!("{}", txv.valid_before),
+            ]);
+            metadata_table.add_row(vec![
+                "Transaction Valid After",
+                &format!("{}", txv.valid_after),
+            ]);
 
             // Print table of actions and their descriptions
             println!("{actions_table}");

--- a/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
+++ b/proto/proto/penumbra/core/transaction/v1alpha1/transaction.proto
@@ -41,6 +41,24 @@ message TransactionBody {
   // An optional encrypted memo. It will only be populated if there are
   // outputs in the actions of this transaction. 528 bytes.
   optional bytes encrypted_memo = 6;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is < this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_before = 7;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is > this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_after = 8;
 }
 
 // A state change performed by a transaction.
@@ -118,6 +136,25 @@ message TransactionView {
   // An optional plaintext memo. It will only be populated if there are
   // outputs in the actions of this transaction.
   optional bytes memo = 6;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is < this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_before = 7;
+  // A unix timestamp, in nanoseconds.
+  // If this value is set, the transaction is valid iff the most recent block header
+  // timestamp is > this value.
+  //
+  // If the value is zero, this value is considered unset.
+  // [TODO: Double check that this actually does behave like google's protobufs]
+  // The behavior of this time stamp should match google's protobuf specification:
+  // [specification]: https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp
+  uint64 valid_after = 8;
+
 }
 
 // A view of a specific state change action performed by a transaction.
@@ -290,6 +327,8 @@ message TransactionPlan {
     crypto.v1alpha1.Fee fee = 4;
     repeated CluePlan clue_plans = 5;
     MemoPlan memo_plan = 6;
+    uint64 valid_before = 7;
+    uint64 valid_after = 8;
 }
 
 // Describes a planned transaction action.

--- a/proto/proto/penumbra/view/v1alpha1/view.proto
+++ b/proto/proto/penumbra/view/v1alpha1/view.proto
@@ -106,6 +106,10 @@ message TransactionPlannerRequest {
     core.crypto.v1alpha1.Fee fee = 2;
     // The memo for the requested TransactionPlan
     string memo = 3;
+    // The valid_before timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    optional string valid_before = 4;
+    // The valid_after timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    optional string valid_after = 5;
     // Identifies the FVK for the notes to query.
     optional core.crypto.v1alpha1.AccountID account_id = 14;
     // Authorizes the request.

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.rs
@@ -45,6 +45,26 @@ pub struct TransactionBody {
     /// outputs in the actions of this transaction. 528 bytes.
     #[prost(bytes = "bytes", optional, tag = "6")]
     pub encrypted_memo: ::core::option::Option<::prost::bytes::Bytes>,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is < this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is > this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// A state change performed by a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -168,6 +188,26 @@ pub struct TransactionView {
     /// outputs in the actions of this transaction.
     #[prost(bytes = "bytes", optional, tag = "6")]
     pub memo: ::core::option::Option<::prost::bytes::Bytes>,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is < this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    /// A unix timestamp, in nanoseconds.
+    /// If this value is set, the transaction is valid iff the most recent block header
+    /// timestamp is > this value.
+    ///
+    /// If the value is zero, this value is considered unset.
+    /// [TODO: Double check that this actually does behave like google's protobufs]
+    /// The behavior of this time stamp should match google's protobuf specification:
+    /// \[specification\]: <https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Timestamp>
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// A view of a specific state change action performed by a transaction.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -494,6 +534,10 @@ pub struct TransactionPlan {
     pub clue_plans: ::prost::alloc::vec::Vec<CluePlan>,
     #[prost(message, optional, tag = "6")]
     pub memo_plan: ::core::option::Option<MemoPlan>,
+    #[prost(uint64, tag = "7")]
+    pub valid_before: u64,
+    #[prost(uint64, tag = "8")]
+    pub valid_after: u64,
 }
 /// Describes a planned transaction action.
 ///

--- a/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.core.transaction.v1alpha1.serde.rs
@@ -4043,6 +4043,12 @@ impl serde::Serialize for TransactionBody {
         if self.encrypted_memo.is_some() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionBody", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
@@ -4061,6 +4067,12 @@ impl serde::Serialize for TransactionBody {
         }
         if let Some(v) = self.encrypted_memo.as_ref() {
             struct_ser.serialize_field("encryptedMemo", pbjson::private::base64::encode(&v).as_str())?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -4082,6 +4094,10 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
             "fmdClues",
             "encrypted_memo",
             "encryptedMemo",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -4092,6 +4108,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
             Fee,
             FmdClues,
             EncryptedMemo,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4119,6 +4137,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                             "fee" => Ok(GeneratedField::Fee),
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
                             "encryptedMemo" | "encrypted_memo" => Ok(GeneratedField::EncryptedMemo),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4144,6 +4164,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                 let mut fee__ = None;
                 let mut fmd_clues__ = None;
                 let mut encrypted_memo__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Actions => {
@@ -4186,6 +4208,22 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                                 map.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| x.0)
                             ;
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionBody {
@@ -4195,6 +4233,8 @@ impl<'de> serde::Deserialize<'de> for TransactionBody {
                     fee: fee__,
                     fmd_clues: fmd_clues__.unwrap_or_default(),
                     encrypted_memo: encrypted_memo__,
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }
@@ -4355,6 +4395,12 @@ impl serde::Serialize for TransactionPlan {
         if self.memo_plan.is_some() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionPlan", len)?;
         if !self.actions.is_empty() {
             struct_ser.serialize_field("actions", &self.actions)?;
@@ -4373,6 +4419,12 @@ impl serde::Serialize for TransactionPlan {
         }
         if let Some(v) = self.memo_plan.as_ref() {
             struct_ser.serialize_field("memoPlan", v)?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -4394,6 +4446,10 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
             "cluePlans",
             "memo_plan",
             "memoPlan",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -4404,6 +4460,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
             Fee,
             CluePlans,
             MemoPlan,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4431,6 +4489,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                             "fee" => Ok(GeneratedField::Fee),
                             "cluePlans" | "clue_plans" => Ok(GeneratedField::CluePlans),
                             "memoPlan" | "memo_plan" => Ok(GeneratedField::MemoPlan),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4456,6 +4516,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                 let mut fee__ = None;
                 let mut clue_plans__ = None;
                 let mut memo_plan__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::Actions => {
@@ -4496,6 +4558,22 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                             }
                             memo_plan__ = map.next_value()?;
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionPlan {
@@ -4505,6 +4583,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlan {
                     fee: fee__,
                     clue_plans: clue_plans__.unwrap_or_default(),
                     memo_plan: memo_plan__,
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }
@@ -4537,6 +4617,12 @@ impl serde::Serialize for TransactionView {
         if self.memo.is_some() {
             len += 1;
         }
+        if self.valid_before != 0 {
+            len += 1;
+        }
+        if self.valid_after != 0 {
+            len += 1;
+        }
         let mut struct_ser = serializer.serialize_struct("penumbra.core.transaction.v1alpha1.TransactionView", len)?;
         if !self.action_views.is_empty() {
             struct_ser.serialize_field("actionViews", &self.action_views)?;
@@ -4555,6 +4641,12 @@ impl serde::Serialize for TransactionView {
         }
         if let Some(v) = self.memo.as_ref() {
             struct_ser.serialize_field("memo", pbjson::private::base64::encode(&v).as_str())?;
+        }
+        if self.valid_before != 0 {
+            struct_ser.serialize_field("validBefore", ToString::to_string(&self.valid_before).as_str())?;
+        }
+        if self.valid_after != 0 {
+            struct_ser.serialize_field("validAfter", ToString::to_string(&self.valid_after).as_str())?;
         }
         struct_ser.end()
     }
@@ -4576,6 +4668,10 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
             "fmd_clues",
             "fmdClues",
             "memo",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
         ];
 
         #[allow(clippy::enum_variant_names)]
@@ -4586,6 +4682,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
             Fee,
             FmdClues,
             Memo,
+            ValidBefore,
+            ValidAfter,
         }
         impl<'de> serde::Deserialize<'de> for GeneratedField {
             fn deserialize<D>(deserializer: D) -> std::result::Result<GeneratedField, D::Error>
@@ -4613,6 +4711,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                             "fee" => Ok(GeneratedField::Fee),
                             "fmdClues" | "fmd_clues" => Ok(GeneratedField::FmdClues),
                             "memo" => Ok(GeneratedField::Memo),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             _ => Err(serde::de::Error::unknown_field(value, FIELDS)),
                         }
                     }
@@ -4638,6 +4738,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                 let mut fee__ = None;
                 let mut fmd_clues__ = None;
                 let mut memo__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 while let Some(k) = map.next_key()? {
                     match k {
                         GeneratedField::ActionViews => {
@@ -4680,6 +4782,22 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                                 map.next_value::<::std::option::Option<::pbjson::private::BytesDeserialize<_>>>()?.map(|x| x.0)
                             ;
                         }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = 
+                                Some(map.next_value::<::pbjson::private::NumberDeserialize<_>>()?.0)
+                            ;
+                        }
                     }
                 }
                 Ok(TransactionView {
@@ -4689,6 +4807,8 @@ impl<'de> serde::Deserialize<'de> for TransactionView {
                     fee: fee__,
                     fmd_clues: fmd_clues__.unwrap_or_default(),
                     memo: memo__,
+                    valid_before: valid_before__.unwrap_or_default(),
+                    valid_after: valid_after__.unwrap_or_default(),
                 })
             }
         }

--- a/proto/src/gen/penumbra.view.v1alpha1.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.rs
@@ -29,6 +29,12 @@ pub struct TransactionPlannerRequest {
     /// The memo for the requested TransactionPlan
     #[prost(string, tag = "3")]
     pub memo: ::prost::alloc::string::String,
+    /// The valid_before timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    #[prost(string, optional, tag = "4")]
+    pub valid_before: ::core::option::Option<::prost::alloc::string::String>,
+    /// The valid_after timestamp for the requested TransactionPlan, formatted as an RFC 3339 timestamp
+    #[prost(string, optional, tag = "5")]
+    pub valid_after: ::core::option::Option<::prost::alloc::string::String>,
     /// Identifies the FVK for the notes to query.
     #[prost(message, optional, tag = "14")]
     pub account_id: ::core::option::Option<

--- a/proto/src/gen/penumbra.view.v1alpha1.serde.rs
+++ b/proto/src/gen/penumbra.view.v1alpha1.serde.rs
@@ -4296,6 +4296,12 @@ impl serde::Serialize for TransactionPlannerRequest {
         if !self.memo.is_empty() {
             len += 1;
         }
+        if self.valid_before.is_some() {
+            len += 1;
+        }
+        if self.valid_after.is_some() {
+            len += 1;
+        }
         if self.account_id.is_some() {
             len += 1;
         }
@@ -4323,6 +4329,12 @@ impl serde::Serialize for TransactionPlannerRequest {
         }
         if !self.memo.is_empty() {
             struct_ser.serialize_field("memo", &self.memo)?;
+        }
+        if let Some(v) = self.valid_before.as_ref() {
+            struct_ser.serialize_field("validBefore", v)?;
+        }
+        if let Some(v) = self.valid_after.as_ref() {
+            struct_ser.serialize_field("validAfter", v)?;
         }
         if let Some(v) = self.account_id.as_ref() {
             struct_ser.serialize_field("accountId", v)?;
@@ -4356,6 +4368,10 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
             "expiryHeight",
             "fee",
             "memo",
+            "valid_before",
+            "validBefore",
+            "valid_after",
+            "validAfter",
             "account_id",
             "accountId",
             "token",
@@ -4370,6 +4386,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
             ExpiryHeight,
             Fee,
             Memo,
+            ValidBefore,
+            ValidAfter,
             AccountId,
             Token,
             Outputs,
@@ -4400,6 +4418,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                             "expiryHeight" | "expiry_height" => Ok(GeneratedField::ExpiryHeight),
                             "fee" => Ok(GeneratedField::Fee),
                             "memo" => Ok(GeneratedField::Memo),
+                            "validBefore" | "valid_before" => Ok(GeneratedField::ValidBefore),
+                            "validAfter" | "valid_after" => Ok(GeneratedField::ValidAfter),
                             "accountId" | "account_id" => Ok(GeneratedField::AccountId),
                             "token" => Ok(GeneratedField::Token),
                             "outputs" => Ok(GeneratedField::Outputs),
@@ -4428,6 +4448,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                 let mut expiry_height__ = None;
                 let mut fee__ = None;
                 let mut memo__ = None;
+                let mut valid_before__ = None;
+                let mut valid_after__ = None;
                 let mut account_id__ = None;
                 let mut token__ = None;
                 let mut outputs__ = None;
@@ -4455,6 +4477,18 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                                 return Err(serde::de::Error::duplicate_field("memo"));
                             }
                             memo__ = Some(map.next_value()?);
+                        }
+                        GeneratedField::ValidBefore => {
+                            if valid_before__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validBefore"));
+                            }
+                            valid_before__ = map.next_value()?;
+                        }
+                        GeneratedField::ValidAfter => {
+                            if valid_after__.is_some() {
+                                return Err(serde::de::Error::duplicate_field("validAfter"));
+                            }
+                            valid_after__ = map.next_value()?;
                         }
                         GeneratedField::AccountId => {
                             if account_id__.is_some() {
@@ -4498,6 +4532,8 @@ impl<'de> serde::Deserialize<'de> for TransactionPlannerRequest {
                     expiry_height: expiry_height__.unwrap_or_default(),
                     fee: fee__,
                     memo: memo__.unwrap_or_default(),
+                    valid_before: valid_before__,
+                    valid_after: valid_after__,
                     account_id: account_id__,
                     token: token__,
                     outputs: outputs__.unwrap_or_default(),

--- a/transaction/src/effect_hash.rs
+++ b/transaction/src/effect_hash.rs
@@ -92,6 +92,8 @@ impl TransactionBody {
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
+        state.update(&self.valid_after.nanoseconds().to_le_bytes());
+        state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
         if self.memo.is_some() {
             let memo = self.memo.clone();
@@ -136,6 +138,8 @@ impl TransactionPlan {
         // Hash the fixed data of the transaction body.
         state.update(chain_id_effect_hash(&self.chain_id).as_bytes());
         state.update(&self.expiry_height.to_le_bytes());
+        state.update(&self.valid_after.nanoseconds().to_le_bytes());
+        state.update(&self.valid_before.nanoseconds().to_le_bytes());
         state.update(self.fee.effect_hash().as_bytes());
 
         // Hash the memo and save the memo key for use with outputs later.
@@ -883,6 +887,8 @@ mod tests {
                 )
                 .unwrap(),
             ),
+            valid_after: ibc::timestamp::Timestamp::none(),
+            valid_before: ibc::timestamp::Timestamp::none(),
         };
 
         println!("{}", serde_json::to_string_pretty(&plan).unwrap());

--- a/transaction/src/plan.rs
+++ b/transaction/src/plan.rs
@@ -2,6 +2,7 @@
 //! creation.
 
 use anyhow::Result;
+use ibc::timestamp::Timestamp;
 use penumbra_crypto::{transaction::Fee, Address};
 use penumbra_proto::{
     core::ibc::v1alpha1 as pb_ibc, core::stake::v1alpha1 as pb_stake,
@@ -40,6 +41,8 @@ pub struct TransactionPlan {
     pub fee: Fee,
     pub clue_plans: Vec<CluePlan>,
     pub memo_plan: Option<MemoPlan>,
+    pub valid_before: Timestamp,
+    pub valid_after: Timestamp,
 }
 
 impl TransactionPlan {
@@ -258,6 +261,8 @@ impl From<TransactionPlan> for pb::TransactionPlan {
         Self {
             actions: msg.actions.into_iter().map(Into::into).collect(),
             expiry_height: msg.expiry_height,
+            valid_after: msg.valid_after.nanoseconds(),
+            valid_before: msg.valid_before.nanoseconds(),
             chain_id: msg.chain_id,
             fee: Some(msg.fee.into()),
             clue_plans: msg.clue_plans.into_iter().map(Into::into).collect(),
@@ -281,6 +286,8 @@ impl TryFrom<pb::TransactionPlan> for TransactionPlan {
                 .map(TryInto::try_into)
                 .collect::<Result<_, _>>()?,
             expiry_height: value.expiry_height,
+            valid_after: Timestamp::from_nanoseconds(value.valid_after)?,
+            valid_before: Timestamp::from_nanoseconds(value.valid_before)?,
             chain_id: value.chain_id,
             fee: value
                 .fee

--- a/transaction/src/plan/build.rs
+++ b/transaction/src/plan/build.rs
@@ -168,6 +168,8 @@ impl TransactionPlan {
         let transaction_body = TransactionBody {
             actions,
             expiry_height: self.expiry_height,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
             chain_id: self.chain_id,
             fee: self.fee,
             fmd_clues,
@@ -387,6 +389,8 @@ impl TransactionPlan {
         let transaction_body = TransactionBody {
             actions,
             expiry_height: self.expiry_height,
+            valid_after: self.valid_after,
+            valid_before: self.valid_before,
             chain_id: self.chain_id,
             fee: self.fee,
             fmd_clues,

--- a/transaction/src/transaction.rs
+++ b/transaction/src/transaction.rs
@@ -29,6 +29,7 @@ use crate::{
     view::action_view::OutputView,
     Action, ActionView, Id, IsAction, TransactionPerspective, TransactionView,
 };
+use ibc::timestamp::Timestamp;
 
 #[derive(Clone, Debug, Default)]
 pub struct TransactionBody {
@@ -38,6 +39,8 @@ pub struct TransactionBody {
     pub fee: Fee,
     pub fmd_clues: Vec<Clue>,
     pub memo: Option<MemoCiphertext>,
+    pub valid_after: Timestamp,
+    pub valid_before: Timestamp,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -171,6 +174,8 @@ impl Transaction {
         TransactionView {
             action_views,
             expiry_height: self.transaction_body().expiry_height,
+            valid_after: self.transaction_body().valid_after,
+            valid_before: self.transaction_body().valid_before,
             chain_id: self.transaction_body().chain_id,
             fee: self.transaction_body().fee,
             fmd_clues: self.transaction_body().fmd_clues,
@@ -379,6 +384,8 @@ impl From<TransactionBody> for pbt::TransactionBody {
         pbt::TransactionBody {
             actions: msg.actions.into_iter().map(|x| x.into()).collect(),
             expiry_height: msg.expiry_height,
+            valid_after: msg.valid_after.nanoseconds(),
+            valid_before: msg.valid_before.nanoseconds(),
             chain_id: msg.chain_id,
             fee: Some(msg.fee.into()),
             fmd_clues: msg.fmd_clues.into_iter().map(|x| x.into()).collect(),
@@ -401,6 +408,8 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
         }
 
         let expiry_height = proto.expiry_height;
+        let valid_before = Timestamp::from_nanoseconds(proto.valid_before)?;
+        let valid_after = Timestamp::from_nanoseconds(proto.valid_after)?;
 
         let chain_id = proto.chain_id;
 
@@ -431,6 +440,8 @@ impl TryFrom<pbt::TransactionBody> for TransactionBody {
         Ok(TransactionBody {
             actions,
             expiry_height,
+            valid_before,
+            valid_after,
             chain_id,
             fee,
             fmd_clues,

--- a/transaction/src/view.rs
+++ b/transaction/src/view.rs
@@ -1,4 +1,5 @@
 use decaf377_fmd::Clue;
+use ibc::timestamp::Timestamp;
 use penumbra_crypto::{memo::MemoPlaintext, transaction::Fee};
 use penumbra_proto::{core::transaction::v1alpha1 as pbt, DomainType};
 use serde::{Deserialize, Serialize};
@@ -14,6 +15,8 @@ pub use transaction_perspective::TransactionPerspective;
 pub struct TransactionView {
     pub action_views: Vec<ActionView>,
     pub expiry_height: u64,
+    pub valid_after: Timestamp,
+    pub valid_before: Timestamp,
     pub chain_id: String,
     pub fee: Fee,
     pub fmd_clues: Vec<Clue>,
@@ -35,6 +38,8 @@ impl TryFrom<pbt::TransactionView> for TransactionView {
                 .map(TryInto::try_into)
                 .collect::<Result<Vec<_>, _>>()?,
             expiry_height: v.expiry_height,
+            valid_after: Timestamp::from_nanoseconds(v.valid_after)?,
+            valid_before: Timestamp::from_nanoseconds(v.valid_before)?,
             chain_id: v.chain_id,
             fee: v
                 .fee
@@ -58,6 +63,8 @@ impl From<TransactionView> for pbt::TransactionView {
         Self {
             action_views: v.action_views.into_iter().map(Into::into).collect(),
             expiry_height: v.expiry_height,
+            valid_after: v.valid_after.nanoseconds(),
+            valid_before: v.valid_before.nanoseconds(),
             chain_id: v.chain_id,
             fee: Some(v.fee.into()),
             fmd_clues: v.fmd_clues.into_iter().map(Into::into).collect(),

--- a/view/src/planner.rs
+++ b/view/src/planner.rs
@@ -33,6 +33,7 @@ use penumbra_transaction::{
     proposal,
 };
 use rand::{CryptoRng, RngCore};
+use tendermint::Time;
 use tracing::instrument;
 
 use crate::{SpendableNoteRecord, ViewClient};
@@ -121,6 +122,20 @@ impl<R: RngCore + CryptoRng> Planner<R> {
     #[instrument(skip(self))]
     pub fn expiry_height(&mut self, expiry_height: u64) -> &mut Self {
         self.plan.expiry_height = expiry_height;
+        self
+    }
+
+    /// Set the timestamp after which this transaction is valid
+    #[instrument(skip(self))]
+    pub fn valid_after(&mut self, valid_after: Time) -> &mut Self {
+        self.plan.valid_after = valid_after.into();
+        self
+    }
+
+    /// Set the timestamp before which this transaction is valid
+    #[instrument(skip(self))]
+    pub fn valid_before(&mut self, valid_before: Time) -> &mut Self {
+        self.plan.valid_before = valid_before.into();
         self
     }
 

--- a/view/src/service.rs
+++ b/view/src/service.rs
@@ -354,6 +354,19 @@ impl ViewProtocolService for ViewService {
             )
             .expiry_height(prq.expiry_height);
 
+        if let Some(timestamp) = prq.valid_after {
+            let time = tendermint::Time::parse_from_rfc3339(timestamp.as_str()).map_err(|e| {
+                tonic::Status::invalid_argument(format!("Could not parse valid_after: {e:#}"))
+            })?;
+            planner.valid_after(time);
+        }
+
+        if let Some(timestamp) = prq.valid_before {
+            let time = tendermint::Time::parse_from_rfc3339(timestamp.as_str()).map_err(|e| {
+                tonic::Status::invalid_argument(format!("Could not parse valid_before: {e:#}"))
+            })?;
+            planner.valid_before(time);
+        }
         for output in prq.outputs {
             let address: penumbra_crypto::Address = output
                 .address


### PR DESCRIPTION
TODO: 
- [x] Add fields to associated protos and wire through the rest of the transaction
- [ ] Double check handling of time / protobuf numbering / error messages with Penumbra devs
- [x] Add check enforcing this validity
- [ ] Write test demonstrating correctness of fields